### PR TITLE
Add Faucet project to projects.json

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -19,6 +19,11 @@
       "name": "4jcraft / 4jcraft",
       "url": "https://github.com/4jcraft/4jcraft",
       "priority": 4
+    },
+    {
+      "name": "SillyProotSoda / Faucet - LCE's Best Modloader!",
+      "url": "https://github.com/ytsodacan/Faucet",
+      "priority": 5
     }
   ]
 }


### PR DESCRIPTION
## Add Project to Minecraft Legacy Index

### Project Details

- **Name:** `SillyProotSoda / Faucet - LCE’s Best Modloader!`
- **URL:** `https://github.com/ytsodacan/Faucet`
- **Priority:** `5`

### Checklist

- [ ok] `projects.json` is valid JSON (no trailing commas, proper quotes)
- [yup ] URL is not already in the list
- [uh huh ] Project is related to Minecraft Legacy / Console Edition
- [yeah ] Only one project added per PR

### Description

<!-- Brief description of the project and why it should be listed -->

It’s like, the best modloader right now, I will be dropping source soon