### PR TITLE
Add MLCE Texture Pack Converter to project list

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -27,7 +27,7 @@
       "priority": 4
     },
     {
-      "name": "SillyProotSoda / Faucet - LCE's Best Modloader!",
+      "name": "SillyProotSoda / Faucet",
       "url": "https://github.com/ytsodacan/Faucet",
       "priority": 6
     }


### PR DESCRIPTION
## Add Project to Minecraft Legacy Index

### Project Details

- **Name:** `owner / ProjectName`
- **URL:** `https://...`
- **Priority:** `(number)`

### Checklist

- [x] `projects.json` is valid JSON (no trailing commas, proper quotes)
- [x] URL is not already in the list
- [x] Project is related to Minecraft Legacy / Console Edition
- [x] Only one project added per PR

### Description

<!-- Brief description of the project and why it should be listed -->

