### PR TITLE
add openLCE to projects

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -46,6 +46,12 @@
       "url": "https://github.com/ASAOddball1/Java-to-MLCE-Texture-Pack-Converter/tree/main",
       "priority": 7,
       "tag": "converter"
+    },
+    {
+      "name": "openLCE",
+      "url": "https://openlce.org",
+      "priority": 8,
+      "tag": "game"
     }
   ]
 }


### PR DESCRIPTION
## Add Project to Minecraft Legacy Index

### Project Details

- **Name:** `openLCE`
- **URL:** `https://openlce.org`
- **Priority:** `8`

### Checklist

- [x] `projects.json` is valid JSON (no trailing commas, proper quotes)
- [x] URL is not already in the list
- [x] Project is related to Minecraft Legacy / Console Edition
- [x] Only one project added per PR

### Description

It's one of the only projects to support building on linux (CMake), modernizing the codebase and we are working on a C++/Lua modloader

