### PR TITLE
Added CE-Compiler-Patcher

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -46,6 +46,12 @@
       "url": "https://github.com/ASAOddball1/Java-to-MLCE-Texture-Pack-Converter/tree/main",
       "priority": 7,
       "tag": "converter"
+    },
+    {
+      "name": "Shortygotsauce / Community Edition",
+      "url": "https://github.com/Shortygotsauce/CE-Compiler-Patcher",
+      "priority": 8,
+      "tag": "tool"
     }
   ]
 }


### PR DESCRIPTION
Add Community Edition Compiler & Patcher to project list

## Add Project to Minecraft Legacy Index

### Project Details

- **Name:** `Shortygotsauce/ Community Edition`
- **URL:** `https://github.com/Shortygotsauce/CE-Compiler-Patcher
- **Priority:** `(8)`

### Checklist

- [x] `projects.json` is valid JSON (no trailing commas, proper quotes)
- [x] URL is not already in the list
- [x] Project is related to Minecraft Legacy / Console Edition
- [x] Only one project added per PR

### Description

The Community Edition is a standalone tool designed to compile, patch, and manage game executables for Minecraft 4J Legacy Console Edition

