### PR TITLE
Add OxyZin / LegacyConsoleLauncher project entry

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -47,7 +47,7 @@
       "priority": 7,
       "tag": "converter"
     },
-        {
+    {
       "name": "OxyZin / LegacyConsoleLauncher",
       "url": "https://github.com/OxyZin/LegacyConsoleLauncher",
       "priority": 8,


### PR DESCRIPTION
## Add Project to Minecraft Legacy Index

### Project Details

- **Name:** `OxyZin / LegacyConsoleLauncher`
- **URL:** `https://github.com/OxyZin/LegacyConsoleLauncher`
- **Priority:** `8`

### Checklist

- [X] `projects.json` is valid JSON (no trailing commas, proper quotes)
- [X] URL is not already in the list
- [X] Project is related to Minecraft Legacy / Console Edition
- [X] Only one project added per PR

### Description

LegacyConsoleLauncher is a lightweight open-source launcher for the Minecraft Legacy Console PC port.

It is focused on simplicity, low resource usage, and compatibility, while still providing useful features such as automatic game installation, automatic updates, account management, playtime tracking, per-account skins, and a built-in skin preview.

The project is specifically made for the Minecraft Legacy Console community and is actively maintained.