### PR TITLE
Add MCPE 0.6.1 to project list

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -46,6 +46,12 @@
       "url": "https://github.com/ASAOddball1/Java-to-MLCE-Texture-Pack-Converter/tree/main",
       "priority": 7,
       "tag": "converter"
+    },
+    {
+      "name": "Kolyah35 / MCPE 0.6.1",
+      "url": "https://gitea.sffempire.ru/Kolyah35/minecraft-pe-0.6.1",
+      "priority": 8,
+      "tag": "game"
     }
   ]
 }


### PR DESCRIPTION
## Add Project to Minecraft Legacy Index

### Project Details

- **Name:** `Kolyah35 / MCPE 0.6.1`
- **URL:** `https://gitea.sffempire.ru/Kolyah35/minecraft-pe-0.6.1`
- **Priority:** `8`

### Checklist

- [x] `projects.json` is valid JSON (no trailing commas, proper quotes)
- [x] URL is not already in the list
- [x] Project is related to Minecraft Legacy / Console Edition
- [x] Only one project added per PR

### Description

We improve the MCPE 0.6.1 experience and add new features. We also work on modern platform compatibility.