### PR TITLE
Update projects.json

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -48,7 +48,7 @@
       "tag": "converter"
     },
     {
-      "name": "ARMS SLIMS AND BODY OVERLAY",
+      "name": "OliverLesen / ARMS SLIMS AND BODY OVERLAY",
       "url": "https://github.com/OliverLesen/MinecraftConsoles",
       "priority": 8,
       "tag": "mod"


### PR DESCRIPTION
## Add Project to Minecraft Legacy Index

### Project Details

- **Name:** `OliverLesen / ARMS SLIMS AND BODY OVERLAY`
- **URL:** `https://github.com/OliverLesen/MinecraftConsoles`
- **Priority:** `8`

### Checklist

- [x] `projects.json` is valid JSON (no trailing commas, proper quotes)
- [x] URL is not already in the list
- [x] Project is related to Minecraft Legacy / Console Edition
- [x] Only one project added per PR

### Description

<!-- This addition I made aims to implement the Steve and Alex skin models with a 64x64 UV map, also adding body, head, leg, and arm layers. I believe it should be accepted because it's something many players miss, as it did for me. I believe this type of feature, which is present in more recent versions, will be missed. -->

