### PR TITLE
remove The archive.org link due to it being taken down.

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -1,12 +1,6 @@
 {
   "repos": [
     {
-      "name": "Archive Source Code Dump",
-      "url": "https://archive.org/download/minecraft-legacy-console-edition-source-code",
-      "priority": 1,
-      "tag": "source"
-    },
-    {
       "name": "smartcmd / MinecraftConsoles",
       "url": "https://github.com/smartcmd/MinecraftConsoles",
       "priority": 2,


### PR DESCRIPTION
## Add Project to Minecraft Legacy Index

### Project Details

- **Name:** `owner / ProjectName`
- **URL:** `https://...`
- **Priority:** `(number)`

### Checklist

- [ ] `projects.json` is valid JSON (no trailing commas, proper quotes)
- [ ] URL is not already in the list
- [ ] Project is related to Minecraft Legacy / Console Edition
- [ ] Only one project added per PR

### Description

removes the link 

