### PR TITLE
Add Synomal / Flint project to projects.json

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -52,6 +52,12 @@
       "url": "https://github.com/OxyZin/LegacyConsoleLauncher",
       "priority": 8,
       "tag": "launcher"
+    },
+    {
+      "name": "Synomal / Flint",
+      "url": "https://github.com/synomal/Flint",
+      "priority": 9,
+      "tag": "launcher"
     }
   ]
 }


### PR DESCRIPTION
## Add Project to Minecraft Legacy Index

### Project Details

- **Name:** `Synomal / Flint`
- **URL:** `https://github.com/synomal/flint`
- **Priority:** `9`

### Checklist

- [x] `projects.json` is valid JSON (no trailing commas, proper quotes)
- [x] URL is not already in the list
- [x] Project is related to Minecraft Legacy / Console Edition
- [x] Only one project added per PR

### Description

My cozy launcher coded in zig with clay and sdl.

