### PR TITLE
Add xgui4 / Legacy-Qt-Launcher project entry

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -52,6 +52,12 @@
       "url": "https://github.com/OxyZin/LegacyConsoleLauncher",
       "priority": 8,
       "tag": "launcher"
+    },
+    {
+      "name": "xgui4 / Legacy-Qt-Launcher",
+      "url": "https://github.com/xgui4/Legacy-Qt-Launcher",
+      "priority": 9,
+      "tag": "launcher"
     }
   ]
 }


### PR DESCRIPTION
## Add Project to Minecraft Legacy Index

### Project Details

- **Name:** `xgui4 / Legacy-Qt-Launcher`
- **URL:** `https://github.com/xgui4/LCE-Qt-Launcher`
- **Priority:** `9`

### Checklist

- [*] `projects.json` is valid JSON (no trailing commas, proper quotes)
- [*] URL is not already in the list
- [*] Project is related to Minecraft Legacy / Console Edition
- [*] Only one project added per PR

### Description

It is a launcher for Minecraft Legacy Console Edition that is written in Python and Pyside6 with QtCreator and VSCode with the focus on GNU/Linux compability and Android with Winlator. This should be added because it is cross-platform but without the electron bloat (which could help for a FreeBSD port) or needed Wine on Linux due to not being a Windows WinForm or WPF or even WinUI. But, also to being respected of user freedom with the GPLv3 license.  

