### PR TITLE
Add DeveloperExotic / Legacy Cross Play to project list

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -56,8 +56,7 @@
     {
       "name": "DeveloperExotic / Legacy Cross Play",
       "url": "https://github.com/DeveloperExotic/LegacyCrossPlay",
-      "priority": 9,
-      "tag": "game"
+      "priority": 9
     }
   ]
 }


### PR DESCRIPTION
## Add Project to Minecraft Legacy Index

### Project Details

- **Name:** `DeveloperExotic / Legacy Cross Play`
- **URL:** `https://github.com/DeveloperExotic/LegacyCrossPlay`
- **Priority:** `(9)`

### Checklist

- [x] `projects.json` is valid JSON (no trailing commas, proper quotes)
- [x] URL is not already in the list
- [x] Project is related to Minecraft Legacy / Console Edition
- [x] Only one project added per PR

### Description

<!-- Brief description of the project and why it should be listed -->
Allows LCE clients to connect to Java Edition 1.8 servers such as Hypixel

