### PR TITLE
add openLCE to projects

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -58,6 +58,12 @@
       "url": "https://github.com/Emerald-Legacy-Launcher/Emerald-Legacy-Launcher",
       "priority": 9,
       "tag": "launcher"
+    },
+    {
+      "name": "openLCE / openLCE",
+      "url": "https://openlce.org",
+      "priority": 10,
+      "tag": "game"
     }
   ]
 }


### PR DESCRIPTION
## Add Project to Minecraft Legacy Index

### Project Details

- **Name:** `openLCE / openLCE`
- **URL:** `https://openlce.org`
- **Priority:** `9`

### Checklist

- [x] `projects.json` is valid JSON (no trailing commas, proper quotes)
- [x] URL is not already in the list
- [x] Project is related to Minecraft Legacy / Console Edition
- [ ] Only one project added per PR

### Description

It's one of the only projects to support building on linux (CMake), modernizing the codebase and we are working on a C++/Lua modloader. You do need an account to view the git repo.

