### PR TITLE
Add Zephelinn / LCDactyl project to projects.json

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -52,7 +52,7 @@
       "url": "https://github.com/OxyZin/LegacyConsoleLauncher",
       "priority": 8,
       "tag": "launcher"
-    }.
+    },
     {
       "name": "Zephelinn / LCDactyl",
       "url": "https://github.com/Zephelinn/LCDactyl",


### PR DESCRIPTION
## Add Zephelinn / LCDactyl Project to Minecraft Legacy Index

### Project Details

- **Name:** `Zephelinn / LCDactyl`
- **URL:** `https://github.com/Zephelinn/LCDactyl)`
- **Priority:** `9`

### Checklist

- [✅] `projects.json` is valid JSON (no trailing commas, proper quotes)
- [✅] URL is not already in the list
- [✅] Project is related to Minecraft Legacy / Console Edition
- [✅] Only one project added per PR

### Description

LCDactyl is a server egg created to run [MinecraftConsoles](https://github.com/smartcmd/MinecraftConsoles) as a headless server utilizing Wine on the [Pterodactyl Panel](https://github.com/pterodactyl/panel).

