### PR TITLE
Added Cactus ModLoader entry

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -60,45 +60,51 @@
       "mirror": "https://git.minecraftlegacy.com/backups/Faucet"
     },
     {
+      "name": "MathiewMay / Cactus ModLoader",
+      "url": "https://github.com/MathiewMay/Cactus.ModLoader",
+      "priority": 10,
+      "tag": "modloader",
+    },
+    {
       "name": "KaDerox / Axo McLCE ModLoader",
       "url": "https://github.com/KaDerox/Axo-McLCE-ModLoader",
-      "priority": 10,
+      "priority": 11,
       "tag": "modloader"
     },
     {
       "name": "ASAOddball / Java to MLCE Texture Pack Converter",
       "url": "https://github.com/ASAOddball1/Java-to-MLCE-Texture-Pack-Converter/tree/main",
-      "priority": 11,
+      "priority": 12,
       "tag": "converter"
     },
     {
       "name": "Minecraft Community Edition",
       "url": "https://github.com/CDevJoud/Minecraft-Community-Edition/tree/main",
-      "priority": 12,
+      "priority": 13,
       "tag": "Game/Server"
     },
     {
       "name": "Emerald-Legacy-Launcher / Emerald-Legacy-Launcher",
       "url": "https://github.com/Emerald-Legacy-Launcher/Emerald-Legacy-Launcher",
-      "priority": 13,
+      "priority": 14,
       "tag": "launcher"
     },
     {
       "name": "OxyZin / LegacyConsoleLauncher",
       "url": "https://github.com/OxyZin/LegacyConsoleLauncher",
-      "priority": 14,
+      "priority": 15,
       "tag": "launcher"
     },
     {
       "name": "neoapps-dev / legacy-launcher",
       "url": "https://github.com/neoapps-dev/legacy-launcher",
-      "priority": 15,
+      "priority": 16,
       "tag": "launcher"
     },
     {
       "name": "xgui4 / Legacy-Qt-Launcher",
       "url": "https://github.com/xgui4/Legacy-Qt-Launcher",
-      "priority": 16,
+      "priority": 17,
       "tag": "launcher"
     }
   ]


### PR DESCRIPTION
## Add Project to Minecraft Legacy Index

### Project Details

- **Name:** `MathiewMay / Cactus ModLoader`
- **URL:** `https://github.com/MathiewMay/Cactus.ModLoader`
- **Priority:** `10`

### Checklist

- [OK] `projects.json` is valid JSON (no trailing commas, proper quotes)
- [OK] URL is not already in the list
- [OK] Project is related to Minecraft Legacy / Console Edition
- [OK] Only one project added per PR

### Description

Cactus ModLoader is a fork-agnostic and cross-platform Mod Loader for LCE, the goal of the project is to have a all-in-one mod loader that can work on any fork of LCE and on any platform (xbox,pc,playstation,etc...) this is acomplished by using cross-platform compatible code and libraries such as lua for scripting.

