### PR TITLE
Change "smartcmd" to "MCLCE" for MinecraftConsoles

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -7,8 +7,8 @@
       "tag": "source"
     },
     {
-      "name": "smartcmd / MinecraftConsoles",
-      "url": "https://github.com/smartcmd/MinecraftConsoles",
+      "name": "MCLCE / MinecraftConsoles (formerly smartcmd)",
+      "url": "https://github.com/MCLCE/MinecraftConsoles",
       "priority": 2,
       "tag": "game",
       "mirror": "https://git.minecraftlegacy.com/backups/MinecraftConsoles"


### PR DESCRIPTION
## Update project info

### Project Details

- **Name:** `MCLCE / MinecraftConsoles`
- **URL:** `https://github.com/MCLCE/MinecraftConsoles`
- **Priority:** `2`

### Checklist

- [x] `projects.json` is valid JSON (no trailing commas, proper quotes)
- [x] Project is related to Minecraft Legacy / Console Edition
- [x] Only one project added per PR

### Description

`smartcmd/MinecraftConsoles` was moved to `MCLCE/MinecraftConsoles` for better organization and security. Links should be updated everywhere to reflect this

