### PR TITLE
Add LCE Save Converter to project list

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -21,84 +21,90 @@
       "mirror": "https://git.minecraftlegacy.com/backups/4jcraft"
     },
     {
+      "name": "dtentiion / LCE Save Converter",
+      "url": "https://github.com/dtentiion/LCE-Save-Converter",
+      "priority": 4,
+      "tag": "converter"
+    },
+    {
       "name": "pieeebot / neoLegacy",
       "url": "https://github.com/LCE-Hub/neoLegacy",
-      "priority": 4,
+      "priority": 5,
       "tag": "game"
     },
-        {
+    {
       "name": "LCEMP / Minecraft LCEMP",
       "url": "https://github.com/LCEMP/LCEMP",
-      "priority": 5,
+      "priority": 6,
       "tag": "game",
       "mirror": "https://git.minecraftlegacy.com/backups/LCEMP"
     },
     {
       "name": "openLCE / openLCE",
       "url": "https://openlce.org",
-      "priority": 6,
+      "priority": 7,
       "tag": "game"
     },
     {
       "name": "gradenGnostic / Legacy Launcher",
       "url": "https://github.com/gradenGnostic/LegacyLauncher",
-      "priority": 7,
+      "priority": 8,
       "tag": "launcher",
       "mirror": "https://git.minecraftlegacy.com/backups/LegacyLauncher"
     },
     {
       "name": "Synomal / Flint",
       "url": "https://github.com/synomal/Flint",
-      "priority": 8,
+      "priority": 9,
       "tag": "launcher"
     },
     {
       "name": "SillyProotSoda / Faucet",
       "url": "https://github.com/ytsodacan/Faucet",
-      "priority": 9,
+      "priority": 10,
       "tag": "mod",
       "mirror": "https://git.minecraftlegacy.com/backups/Faucet"
     },
     {
       "name": "KaDerox / Axo McLCE ModLoader",
       "url": "https://github.com/KaDerox/Axo-McLCE-ModLoader",
-      "priority": 10,
+      "priority": 11,
       "tag": "modloader"
     },
     {
       "name": "ASAOddball / Java to MLCE Texture Pack Converter",
       "url": "https://github.com/ASAOddball1/Java-to-MLCE-Texture-Pack-Converter/tree/main",
-      "priority": 11,
+      "priority": 12,
       "tag": "converter"
     },
     {
       "name": "Minecraft Community Edition",
       "url": "https://github.com/CDevJoud/Minecraft-Community-Edition/tree/main",
-      "priority": 12,
+      "priority": 13,
       "tag": "Game/Server"
     },
     {
       "name": "Emerald-Legacy-Launcher / Emerald-Legacy-Launcher",
       "url": "https://github.com/Emerald-Legacy-Launcher/Emerald-Legacy-Launcher",
-      "priority": 13,
+      "priority": 14,
       "tag": "launcher"
     },
     {
       "name": "OxyZin / LegacyConsoleLauncher",
       "url": "https://github.com/OxyZin/LegacyConsoleLauncher",
-      "priority": 14,
+      "priority": 15,
       "tag": "launcher"
     },
     {
       "name": "neoapps-dev / legacy-launcher",
       "url": "https://github.com/neoapps-dev/legacy-launcher",
-      "priority": 15,
+      "priority": 16,
       "tag": "launcher"
     },
     {
       "name": "xgui4 / Legacy-Qt-Launcher",
       "url": "https://github.com/xgui4/Legacy-Qt-Launcher",
-      "priority": 16,
+      "priority": 17,
       "tag": "launcher"
     }
   ]


### PR DESCRIPTION
## Add Project to Minecraft Legacy Index

### Project Details

- **Name:** `dtentiion / LCE Save Converter`
- **URL:** `https://github.com/dtentiion/LCE-Save-Converter`
- **Priority:** `4`

### Checklist

- [x] `projects.json` is valid JSON (no trailing commas, proper quotes)
- [x] URL is not already in the list
- [x] Project is related to Minecraft Legacy / Console Edition
- [x] Only one project added per PR

### Description

First tool to do a full 1:1 conversion of Xbox 360 Minecraft Legacy Console Edition saves to the Windows 64 LCE format. All world data is preserved - terrain, chests, items, signs, maps, player inventories, Nether/End dimensions. Currently supports Xbox 360 .bin saves, with support for other LCE platform save formats planned for the future.