### PR TITLE
Add LCEList to project list.

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -106,6 +106,12 @@
       "url": "https://github.com/xgui4/Legacy-Qt-Launcher",
       "priority": 17,
       "tag": "launcher"
+    },
+    {
+      "name": "SyddersLMAO / LCEList",
+      "url": "https://lcelist.xyz",
+      "priority": 18,
+      "tag": "contet distribution"
     }
   ]
 }

--- a/projects.json
+++ b/projects.json
@@ -111,7 +111,7 @@
       "name": "SyddersLMAO / LCEList",
       "url": "https://lcelist.xyz",
       "priority": 18,
-      "tag": "contet distribution"
+      "tag": "content distribution"
     }
   ]
 }


### PR DESCRIPTION
## Add Project to Minecraft Legacy Index

### Project Details

- **Name:** `SyddersLMAO / LCEList`
- **URL:** `https://lcelist.xyz`
- **Priority:** `18`

### Checklist

- [x] `projects.json` is valid JSON (no trailing commas, proper quotes)
- [x] URL is not already in the list
- [x] Project is related to Minecraft Legacy / Console Edition
- [x] Only one project added per PR

### Description
LCEList is a content distributing platform for LCEList featuring mods, texture packs, skin packs, and worlds with servers coming soon. It gives users the ability to upload their content to the site ready to share to oter people.

